### PR TITLE
Add support for specifying bed size, therefore centering the part within the bed.

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -19,3 +19,9 @@ brimCount 11
 TipRadius 0.2	 //Used for nozzle compensation, set to 0 to disable.
 FirmwareRetract false
 OuterFirst true 	//Print shells outside first or inside first. In general, try to print lower ones first.
+XMax 200 mm
+YMax 200 mm
+ZMax 200 mm
+XMin 0 mm
+YMin 0 mm
+ZMin 0 mm

--- a/config.txt
+++ b/config.txt
@@ -15,7 +15,7 @@ retractThreshold 10 mm	//Minimum XY travel distance to trigger retraction.
 topLayers 5  //Solid layers on the top and bottom.
 botLayers 5
 AllSolid true  //Print all layers as solid.
-brimCount 11
+brimCount 0
 TipRadius 0.2	 //Used for nozzle compensation, set to 0 to disable.
 FirmwareRetract false
 OuterFirst true 	//Print shells outside first or inside first. In general, try to print lower ones first.

--- a/src/main/Slicer.java
+++ b/src/main/Slicer.java
@@ -50,7 +50,12 @@ public class Slicer {
 	public double retraction;
 	public double retractSpeed;
 	public double retractThreshold;
-	public double zMin = 0;
+    public double xMax = 0;
+    public double yMax = 0;
+    public double zMax = 0;
+    public double xMin = 0;
+    public double yMin = 0;
+    public double zMin = 0;
 	public boolean FirmwareRetract = false;
 	public int topLayerStart;
 	public int botLayers;
@@ -66,7 +71,8 @@ public class Slicer {
 	public double minInfillLength = 0.5;
 	public Slicer(Model3D part, Surface3D shape, double layerHeight, double filD, double nozzleD, double extrusionWidth,
 			int printTemp, int xySpeed, int zSpeed, int numShells, double infillWidth, int infillDir, int infillAngle, 
-			double lift, double retraction, double retractSpeed, double retractThreshold, int topLayers, int botLayers) throws IOException{
+			double lift, double retraction, double retractSpeed, double retractThreshold, int topLayers, int botLayers,
+            double xMax, double yMax, double zMax, double xMin, double yMin, double zMin) throws IOException{
 		this.filD = filD;
 		this.nozzleD = nozzleD;
 		this.extrusionWidth = extrusionWidth;
@@ -88,6 +94,13 @@ public class Slicer {
 		this.layerCount = layerCount();
 		this.topLayerStart = layerCount-topLayers;
 		this.botLayers = botLayers;
+        this.xMax = xMax;
+        this.yMax = yMax;
+        this.zMax = zMax;
+        this.xMin = xMin;
+        this.yMin = yMin;
+        this.zMin = zMin;
+
 		//Cross sectional area of the extrusion is the ratio of plastic volume/XYZ distance, units mm^2
 		//volume rate * filament distance/unit volume = filament rate. filament distance/unit volume is cx area of filament.
 		this.EperL = (((extrusionWidth-layerHeight)*extrusionWidth+3.14*Math.pow(layerHeight,2)/4))/Math.pow(filD,2);
@@ -181,6 +194,24 @@ public class Slicer {
 				case "OuterFirst":
 					this.OuterFirst = Boolean.parseBoolean(line[1]);
 					break;
+                case "XMax":
+                    this.xMax = Double.parseDouble(line[1]);
+                    break;
+                case "YMax":
+                    this.yMax = Double.parseDouble(line[1]);
+                    break;
+                case "ZMax":
+                    this.zMax = Double.parseDouble(line[1]);
+                    break;
+                case "XMin":
+                    this.xMin = Double.parseDouble(line[1]);
+                    break;
+                case "YMin":
+                    this.yMin = Double.parseDouble(line[1]);
+                    break;
+                case "ZMin":
+                    this.zMin = Double.parseDouble(line[1]);
+                    break;
 				}
 			}
 			this.EperL = (((extrusionWidth-layerHeight)*extrusionWidth+3.14*Math.pow(layerHeight,2)/4))/Math.pow(filD,2);

--- a/src/main/Slicer.java
+++ b/src/main/Slicer.java
@@ -45,7 +45,6 @@ public class Slicer {
 	public double infillDir = 45*Math.PI/180.0;	//Direction of infill on layer 0;
 	public double infillAngle = 90*Math.PI/180.0;	//Amount to change infill direction each layer, radians CW.
 	public double lift;	//Amount to lift for travel moves.
-	public LineSegment2D[] topo;
 	public double EperL;	//E increase per unit L increase.
 	public double retraction;
 	public double retractSpeed;
@@ -90,7 +89,7 @@ public class Slicer {
 		this.infillAngle = infillAngle*Math.PI/180.0;
 		this.part = part;
 		this.shape = shape;
-		this.topo = shape.topology();
+		shape.generateTopology();
 		this.lift = lift;
 		this.retraction = retraction;
 		this.retractSpeed = retractSpeed;
@@ -219,7 +218,7 @@ public class Slicer {
             this.setBedDimensions(new Vector3D(xMin, yMin, zMin), new Vector3D(xMax, yMax, zMax));
 
 			this.EperL = (((extrusionWidth-layerHeight)*extrusionWidth+3.14*Math.pow(layerHeight,2)/4))/Math.pow(filD,2);
-			this.topo = shape.topology();
+			shape.generateTopology();
 			this.layerCount = layerCount();
 			this.topLayerStart = layerCount-topLayerStart;
 

--- a/src/mesh3d/Mesh3D.java
+++ b/src/mesh3d/Mesh3D.java
@@ -26,15 +26,14 @@ abstract class Mesh3D implements Shape3D{
 	 * This should probably be changed to return a new Mesh to match the functionality of Tri3D.move, and to make multithreading
 	 * step 1 easy/possible.
 	 */
-	public void move(Vector3D v){{
+	public void move(Vector3D v){
 		Tri3D[] newTris = new Tri3D[tris.length];
 		int i=0;
 		for(Tri3D t:tris){
 			newTris[i]=t.move(v);
 			i++;
-			}
+        }
 		tris=newTris;
-		};
 	}
 	/**
 	 * @param v Direction to search

--- a/src/mesh3d/Surface3D.java
+++ b/src/mesh3d/Surface3D.java
@@ -17,7 +17,9 @@ import math.geom3d.line.StraightLine3D;
 
 public class Surface3D extends Mesh3D{
 	double offset;	//Z offset applied to this surface.
-	private Hashtable<Point2D,Tri3D> TriMap;
+
+    public LineSegment2D[] topo;
+    private Hashtable<Point2D,Tri3D> TriMap;
 	private ArrayList<Point2D> ps;
 	private double MaxRad;	//Length of the longest edge in this mesh, useful for reprojection.
 	private boolean PerimsMade = false;
@@ -53,7 +55,7 @@ public class Surface3D extends Mesh3D{
 
 	@Override
 	public boolean closed(){return false;};
-	
+
 	public LineSegment3D[] overlap(Mesh3D m){
 		LineSegment3D[] output = new LineSegment3D[m.triCount()*this.triCount()];
 		int j=0;
@@ -82,7 +84,7 @@ public class Surface3D extends Mesh3D{
 	 * the output of this function is a set of 2D line segments.
 	 * @return A 2d projection of this Surface's topology.
 	 */
-	public LineSegment2D[] topology(){
+	public LineSegment2D[] generateTopology(){
 		ArrayList<LineSegment2D> output = new ArrayList<LineSegment2D>();;
 		for(Tri3D t:tris){
 			Point2D[] ps = t.getPoints2D();
@@ -105,7 +107,8 @@ public class Surface3D extends Mesh3D{
 				if(checks[i])output.add(ls[i]);
 			}
 		}
-		return output.toArray(new LineSegment2D[output.size()]);
+        this.topo = output.toArray(new LineSegment2D[output.size()]);
+		return this.topo;
 	}
 	/**
 	 * Set the amount by which this surface is offset from its "true" position in the Z axis.
@@ -145,16 +148,10 @@ public class Surface3D extends Mesh3D{
 		return null;
 	}
 	@Override
-	public void move(Vector3D v){{
-		Tri3D[] newTris = new Tri3D[tris.length];
-		int i=0;
-		for(Tri3D t:tris){
-			newTris[i]=t.move(v);
-			i++;
-			}
-		tris=newTris;
-		};
+	public void move(Vector3D v) {
+        super.move(v);
 		makeMaps();
+        generateTopology();
 	}
 	public double getOffset() {
 		return offset;

--- a/src/mesh3d/Surface3D.java
+++ b/src/mesh3d/Surface3D.java
@@ -136,6 +136,8 @@ public class Surface3D extends Mesh3D{
 			}
 			//Otherwise the associated triangle can't possibly reach this point.
 		}
+
+        // If we got here, that means the point is trying to be projected outside of the bounding box.
 		Box3D b = this.boundingBox();
 		System.out.println("Point " + p.getX()+" "+p.getY() + " Failed to project.");
 		System.out.println("X bounds: "+ b.getMinX()+" : "+b.getMaxX()+" Y bounds: "+b.getMinY()+" : "+b.getMaxY());

--- a/src/process/Reproject.java
+++ b/src/process/Reproject.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 
 import main.Slicer;
 import math.geom2d.Point2D;
+import math.geom3d.Box3D;
 import math.geom3d.Point3D;
 import math.geom3d.Vector3D;
 import structs.Extrusion2D;
@@ -80,6 +81,16 @@ public class Reproject {
 	 */
 	private Point3D projectPoint(Point2D p){
 		Point3D hit = s.shape.project(p);
+
+        if(hit == null) {
+            Box3D bb = s.shape.boundingBox();
+
+            // IF WE GOT HERE IT'S BAD. IT MEANS A POINT WAS PROJECTED OUTSIDE OF THE BOUNDING BOX
+            // I feel bad.
+            // Sorry for yelling.
+            hit = s.shape.project(new Point2D(bb.getMinX(), bb.getMinY()));
+        }
+
 		if(hit.getZ()+to()<s.zMin){	//TODO reimplement this check in a way that doesn't cause discontinuities.
 			return new Point3D(hit.getX(),hit.getY(),s.zMin);
 		}

--- a/src/process/Reproject.java
+++ b/src/process/Reproject.java
@@ -88,7 +88,7 @@ public class Reproject {
             // IF WE GOT HERE IT'S BAD. IT MEANS A POINT WAS PROJECTED OUTSIDE OF THE BOUNDING BOX
             // I feel bad.
             // Sorry for yelling.
-            hit = s.shape.project(new Point2D(bb.getMinX(), bb.getMinY()));
+            hit = new Point3D(p.getX(), p.getY(), to());
         }
 
 		if(hit.getZ()+to()<s.zMin){	//TODO reimplement this check in a way that doesn't cause discontinuities.

--- a/src/process/Reproject.java
+++ b/src/process/Reproject.java
@@ -83,11 +83,7 @@ public class Reproject {
 		Point3D hit = s.shape.project(p);
 
         if(hit == null) {
-            Box3D bb = s.shape.boundingBox();
-
-            // IF WE GOT HERE IT'S BAD. IT MEANS A POINT WAS PROJECTED OUTSIDE OF THE BOUNDING BOX
-            // I feel bad.
-            // Sorry for yelling.
+            // If we failed to project the point, just project the 2d point in to 3d space by directly converting a 2d point in to a 3d point, using a calculated z height.
             hit = new Point3D(p.getX(), p.getY(), to());
         }
 

--- a/src/structs/Layer.java
+++ b/src/structs/Layer.java
@@ -115,8 +115,8 @@ public class Layer {
 					lp,
 					np,
 					lp.distance(np)>s.retractThreshold ? ET.travel : ET.nonretracting)	//Retract is 0, nonretracting is 3.
-					).splitExtrusion(s.topo));
+					).splitExtrusion(s.shape.topo));
 		}
-		output.addAll(e.splitExtrusion(s.topo));
+		output.addAll(e.splitExtrusion(s.shape.topo));
 	}
 }


### PR DESCRIPTION
Title says it all. There were a few things that needed to be changed though:
- For example, the Slicer object no longer contains an instance of the topography of the part. That is now stored within the Surface3D object. 
- The topology() method on the surface3d object has been changed to generateTopology(). This is because it's no longer really a getter, and is more of a "horse update the topology because something changed."
- The move function in Surface3D now just calls the Mesh3D's move function (they were identical) and then regenerates it's topology.

Also, one side-effect of this, is that some processes seem to cause points to be placed at 0,0. Using the cube wave model thing, there are 3 when I try to generate the gcode for my bed.  The gcode looks fine aside from that, though.

Let me know if there are any stylistic changes you want me to make to the code.
