### PR TITLE
Fix printing E moves twice for each line

### DIFF
--- a/src/io/GcodeExport.java
+++ b/src/io/GcodeExport.java
@@ -165,7 +165,7 @@ public class GcodeExport {
 					" J" + Constants.xyz.format(n.getY()) +
 					" K" + Constants.xyz.format(n.getZ()));
 		}
-		w.print(" E"+Constants.ext.format(currE) + "\n");
+		w.print("\n");
 		
 	}
 	/**


### PR DESCRIPTION
E moves were being printed twice on each line, i.e.
`G1 X111.742 Y115.362 Z0.225 E2.35796 E2.35796`
and now it looks like this:
`G1 X111.742 Y115.362 Z0.225 E2.35796`
I had a couple hangs trying when trying to print and this change fixed it (I think).

On a separate note, do you have any plans to work on this project again? I know there hasn't been updates  since 2016, but none of the current popular slicers can do 3d layers like this, and considering the way they're built they probably never will. I wouldn't mind contributing some time into the project either if it helps. It seems like there's a lot of potential for this kind of approach and I'd love to see it develop further.